### PR TITLE
adapter method ignores the parameter

### DIFF
--- a/complete/src/main/java/hello/Application.java
+++ b/complete/src/main/java/hello/Application.java
@@ -33,7 +33,7 @@ public class Application {
     @Bean
     MessageListenerAdapter adapter(Receiver receiver) {
         MessageListenerAdapter messageListener
-                = new MessageListenerAdapter(receiver());
+                = new MessageListenerAdapter(receiver);
         messageListener.setDefaultListenerMethod("receiveMessage");
         return messageListener;
     }


### PR DESCRIPTION
The method should return a MessageListenerAdapter wrapping the Reciever
that was passed in. Instead it was creating a new instance. Now it uses
the one it was given.
It looks like this bug crept in 24 days ago when the method was rewritten in [this commit](https://github.com/fisco-unimatic/gs-messaging-jms/commit/21a13fdab97ae7e357fb30adb9a294fa6c593325).
