### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ From here, you can define a message receiver:
 include::complete/src/main/java/hello/Receiver.java[]
 ----
 
-`Receiver` is also known as a **message driven POJO**. As you can see in the code above, there is no need to implement any particular interface or for the method to have any particular name. Besides, the method may have a http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#jms-annotated-method-signature[very flexible signature]. Note in particular that this class has no import on the JMS API.
+`Receiver` is also known as a **message driven POJO**. As you can see in the code above, there is no need to implement any particular interface or for the method to have any particular name. Besides, the method may have a https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#jms-annotated-method-signature[very flexible signature]. Note in particular that this class has no import on the JMS API.
 
 The `JmsListener` annotation defines the name of the `Destination` that this method should listen to and the reference to the `JmsListenerContainerFactory` to use to create the underlying message listener container. Strictly speaking that last attribute is not necessary unless you need to customize the way the container is built as Spring Boot registers a default factory if necessary.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 301).