### PR TITLE
Correct dependencies and configuration after Artemis switch

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -14,6 +14,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-artemis'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	runtimeOnly 'org.apache.activemq:artemis-jakarta-server'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -21,7 +21,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-artemis</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-json</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>artemis-jakarta-server</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/complete/src/main/resources/application.properties
+++ b/complete/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.artemis.mode=embedded

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -14,6 +14,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-artemis'
+	implementation 'org.springframework.boot:spring-boot-starter-json'
+	runtimeOnly 'org.apache.activemq:artemis-jakarta-server'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -21,7 +21,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-artemis</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-json</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>artemis-jakarta-server</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
Unlike ActiveMQ, Artemis does not pull in Jackson transitively so a dependency on spring-boot-starter-json is required to be able to use MappingJackson2MessageConverter.

To avoid having to run an external broker, the guide uses an embedded broker. However, Artemis does not run in embedded mode by default and spring-boot-starter-artemis does not contain the necessary dependencies. Configuration properties and a dependency on artemis-jakarta-server have been added to allow Artemis to run in embedded mode.